### PR TITLE
try preferred citation to add the doi in generated citation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -26,12 +26,13 @@ keywords:
 license: Apache-2.0
 preferred-citation:
   type: software
+  title: xarray-einstats
   authors:
   - family-names: Abril-Pla
     given-names: Oriol
     orcid: 'https://orcid.org/0000-0002-1847-9481'
   doi: 10.5281/zenodo.5895451
-  title: xarray-einstats
+  url: 'https://github.com/arviz-devs/xarray-einstats'
   year: 2022
   publisher: Zenodo
   license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ message: >-
 type: software
 authors:
   - given-names: Oriol
-    family-names: Abril Pla
+    family-names: Abril-Pla
     email: oriol.abril.pla@gmail.com
     affiliation: Helsinki University
     orcid: 'https://orcid.org/0000-0002-1847-9481'
@@ -24,3 +24,14 @@ keywords:
   - statistics
   - labeled arrays
 license: Apache-2.0
+preferred-citation:
+  type: software
+  authors:
+  - family-names: Abril-Pla
+    given-names: Oriol
+    orcid: 'https://orcid.org/0000-0002-1847-9481'
+  doi: 10.5281/zenodo.5895451
+  title: xarray-einstats
+  year: 2022
+  publisher: Zenodo
+  license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -332,8 +332,9 @@ or in bibtex format:
 ```bibtex
 @software{xarray_einstats2022,
   author       = {Abril-Pla, Oriol},
-  title        = {arviz-devs/xarray-einstats},
+  title        = {{xarray-einstats}},
   year         = 2022,
+  url          = {https://github.com/arviz-devs/xarray-einstats}
   publisher    = {Zenodo},
   version      = {<version>},
   doi          = {<version_doi>},

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -2,15 +2,14 @@
 
 ## Unreleased (v0.x.x)
 ### New Features
-* Added `skew` and `kurtosis` to `stats` module {pull}`3`
-
-### Deprecation
+* Added `skew`, `kurtosis` and `median_abs_deviation` to `stats` module {pull}`3`, {pull}`4`
 
 ### Maintenance and fixes
 * Changed the automatic names in einops module to use dashes instead of commas
 
 ### Documentation
 * Added info on how to cite the library on README and citation file
+* Added background/explanation page for the stats module.
 
 ### Developer facing changes
 * Added how-to release guide


### PR DESCRIPTION
The cite this repository button generated by github currenly copies the following text to the clipboard:

```bibtex
@software{Abril_Pla_xarray-einstats,
author = {Abril Pla, Oriol},
license = {Apache-2.0},
title = {{xarray-einstats}},
url = {https://github.com/arviz-devs/xarray-einstats}
}
```

which completely ignores the doi even though it is provided as identifier. There is also an option for "preferred citation" that can be used to point to an article instead. This PR tries to use that to generate still a software citation but with the **general** Zenodo doi for this repository.

Note: Zenodo and releases are a cyclic dependency. The doi is only generated once the release is crafted, so the released code **can't** include the right doi. 

This branch currently generates this:

```bibtex
@software{Abril-Pla_xarray-einstats_2022,
author = {Abril-Pla, Oriol},
doi = {10.5281/zenodo.5895451},
license = {Apache-2.0},
title = {{xarray-einstats}},
url = {https://github.com/arviz-devs/xarray-einstats},
year = {2022}
}
```

will think about what should be present and update accordingly. Some info like the publisher is ignored (I guess for software type citations) even if provided inside the preferred_ctation section.