### PR TITLE
Catch positive definite error

### DIFF
--- a/src/xarray_einstats/stats.py
+++ b/src/xarray_einstats/stats.py
@@ -5,8 +5,8 @@ from collections.abc import Sequence
 
 import numpy as np
 import xarray as xr
-from scipy import stats
 from numpy.linalg import LinAlgError
+from scipy import stats
 
 from .linalg import cholesky, eigh
 
@@ -369,7 +369,7 @@ class multivariate_normal:  # pylint: disable=invalid-name
         except LinAlgError:
             k = len(cov[dim1])
             eye = xr.DataArray(np.eye(k), dims=list(dims))
-            cov_chol = cholesky(cov + 1e-10*eye, dims=dims)
+            cov_chol = cholesky(cov + 1e-10 * eye, dims=dims)
         std_norm = XrContinuousRV(stats.norm, xr.zeros_like(mean.rename({dim1: dim2})), 1)
         samples = std_norm.rvs(size=size, dims=rv_dims, random_state=random_state)
         return mean + xr.dot(cov_chol, samples, dims=dim2)


### PR DESCRIPTION
Even though the docstring from https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.multivariate_normal.html says 

> Symmetric positive (semi)definite covariance matrix of the distribution.

It also accepts matrices whose determinant is close to 0 but negative, generally due to numerical issues. It doesn't expect users to solve those numerical issues themselves before passing the covariance matrix to the multivariate_normal class or methods. This adds a try/except to catch the error related to this issue and checks if adding an identity matrix with 1e-10 to the provided covariance matrix solves the issue.

cc @symeneses