### PR TITLE
Use Read the Docs action v1

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -11,6 +11,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/readthedocs-preview@main
+      - uses: readthedocs/actions/preview@v1
         with:
           project-slug: "xarray-einstats"


### PR DESCRIPTION
Read the Docs repository was renamed from `readthedocs/readthedocs-preview` to `readthedocs/actions/`. Now, the `preview` action is under `readthedocs/actions/preview` and is tagged as `v1`

<!-- readthedocs-preview xarray-einstats start -->
----
:books: Documentation preview :books:: https://xarray-einstats--31.org.readthedocs.build/en/31/

<!-- readthedocs-preview xarray-einstats end -->