### PR TITLE
DOC: Make some URLs clickable in documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,17 +34,17 @@ If you have experienced or witnessed behavior that violates this
 Code of Conduct, please complete the form below to
 make a report.
 
-**REPORTING FORM:** https://numfocus.typeform.com/to/ynjGdT
+**REPORTING FORM:** [https://numfocus.typeform.com/to/ynjGdT](https://numfocus.typeform.com/to/ynjGdT)
 
 Reports are sent to the NumFOCUS Code of Conduct Enforcement Team
 (see below).
 
 You can view the Privacy Policy and Terms of Service for TypeForm here.
-The NumFOCUS Privacy Policy is here:
-https://www.numfocus.org/privacy-policy
+The NumFOCUS Privacy Policy is here: 
+[https://www.numfocus.org/privacy-policy](https://www.numfocus.org/privacy-policy)
 
 
 # Full Code of Conduct
 The full text of the NumFOCUS/xarray-einstats Code of Conduct can be found on
 NumFOCUS's website  
-https://numfocus.org/code-of-conduct
+[https://numfocus.org/code-of-conduct](https://numfocus.org/code-of-conduct)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing guidelines
 
-The contributing guidelines are published at [our documentation](https://xarray-einstats.readthedocs.io/en/latest/contributing.html)
+The contributing guidelines are published at [our documentation](https://einstats.python.arviz.org/en/latest/contributing/overview.html)
 

--- a/docs/source/background/einops.md
+++ b/docs/source/background/einops.md
@@ -11,7 +11,9 @@ Why change the notation? There are three main reasons, each concerning one
 of the elements respectively: `->`, space as delimiter and parenthesis:
 * In xarray dimensions are already labeled. In many cases, the left
   side in the einops notation is only used to label the dimensions.
-  In fact, 5/7 examples in https://einops.rocks/api/rearrange/ fall in this category.
+  In fact, 5/7 examples in
+  [https://einops.rocks/api/rearrange/](https://einops.rocks/api/rearrange/)
+  fall in this category.
   This is not necessary when working with xarray objects.
 * In xarray dimension names can be any {term}`hashable <xarray:name>`.
 * In xarray dimensions are labeled and the order doesn't matter.


### PR DESCRIPTION
Make some URLs clickable in documentation.

<!-- readthedocs-preview xarray-einstats start -->
----
📚 Documentation preview 📚: https://xarray-einstats--71.org.readthedocs.build/en/71/

<!-- readthedocs-preview xarray-einstats end -->