### PR TITLE
Replace Twitter with BlueSky link for social media

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -150,7 +150,7 @@ How-to guides <contributing/how_to>
 :caption: About
 :hidden:
 
-Twitter <https://twitter.com/arviz_devs>
+BlueSky <https://bsky.app/profile/arviz.bsky.social>
 Mastodon <https://bayes.club/@ArviZ>
 GitHub repository <https://github.com/arviz-devs/xarray-einstats>
 ```


### PR DESCRIPTION
Replace Twitter with BlueSky link for social media.

On Arviz Base, the three links are BlueSky, Mastodon, and GitHub repository.
https://arviz-base.readthedocs.io/en/latest/ 