### PR TITLE
DOC: Correct typos in linalg_tutorial.ipynb

### DIFF
--- a/docs/source/tutorials/linalg_tutorial.ipynb
+++ b/docs/source/tutorials/linalg_tutorial.ipynb
@@ -27,7 +27,7 @@
    "id": "60f466a1",
    "metadata": {},
    "source": [
-    "We start by generating syntetic data to work with:"
+    "We start by generating synthetic data to work with:"
    ]
   },
   {
@@ -5442,7 +5442,7 @@
    "id": "664dde4c",
    "metadata": {},
    "source": [
-    "The same can be dome with multiple dimensions."
+    "The same can be done with multiple dimensions."
    ]
   },
   {
@@ -9426,9 +9426,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python [conda env:base] *",
    "language": "python",
-   "name": "python3"
+   "name": "conda-base-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -9440,7 +9440,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Correct typos in `linalg_tutorial.ipynb`:
https://einstats.python.arviz.org/en/latest/tutorials/linalg_tutorial.html

<!-- readthedocs-preview xarray-einstats start -->
----
📚 Documentation preview 📚: https://xarray-einstats--79.org.readthedocs.build/en/79/

<!-- readthedocs-preview xarray-einstats end -->